### PR TITLE
Custom hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainframework/signals",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Signals library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/shared/hooks/useCustomeSynceExternalStore.ts
+++ b/src/shared/hooks/useCustomeSynceExternalStore.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState, useCallback } from "react";
+
+import { isEqual } from "../utils/equalityCheck";
+
+type Comparator<T> = (prev: T, next: T) => boolean;
+
+export const useCustomSyncExternalStore = <T>(
+  subscribe: (callback: () => void) => () => void,
+  getSnapshot: () => T,
+  customComparator: Comparator<T> = isEqual, //Provide a default comparator
+): T => {
+  // Use useState to store the snapshot and trigger re-renders
+  const [snapshot, setSnapshot] = useState(getSnapshot);
+
+  // Handle store updates and decide whether to update the snapshot
+  const handleStoreUpdate = useCallback(() => {
+    const newSnapshot = getSnapshot();
+
+    // Use custom comparator or fallback to strict equality
+    const shouldUpdate = !customComparator(snapshot, newSnapshot);
+
+    if (shouldUpdate) {
+      setSnapshot(newSnapshot); // Update state, triggers re-render
+    }
+  }, [customComparator, getSnapshot, snapshot]);
+
+  // Subscribe to the store and clean up
+  useEffect(() => {
+    const unsubscribe = subscribe(handleStoreUpdate);
+    handleStoreUpdate(); // Check initially when subscribing
+
+    return () => unsubscribe();
+  }, [subscribe, handleStoreUpdate]);
+
+  // Return the current snapshot
+  return snapshot;
+};

--- a/src/shared/hooks/useSignal.ts
+++ b/src/shared/hooks/useSignal.ts
@@ -1,13 +1,11 @@
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+
+import { useCustomSyncExternalStore } from "./useCustomeSynceExternalStore";
 
 import { signal, destroySignal } from "../utils/signals";
 
-export const useSignal = <T>(
-  initialValue: (Partial<T> | T) | Promise<T> | (() => Promise<T>),
-  //using the type 'any' here, because TS suddenly started complaining when this hook is used that it can't infer the type being returend.
-  //Should be T instead, but it's not working.
-): [any, (newValue: T | Promise<T> | (() => Promise<T>)) => void] => {
+export const useSignal = <T>(initialValue: (Partial<T> | T) | Promise<T> | (() => Promise<T>)) => {
   const location = useLocation();
   const [uuid] = useState<string>(() => window.crypto.randomUUID());
   const { get, set, subscribe } = signal(uuid, initialValue);
@@ -18,7 +16,8 @@ export const useSignal = <T>(
     return unsubscribe;
   };
 
-  const value = useSyncExternalStore(subscribeCallback, getSnapshot);
+  //This is for client side rendering only.
+  const value = useCustomSyncExternalStore(subscribeCallback, getSnapshot);
 
   useEffect(() => {
     return () => {
@@ -27,5 +26,5 @@ export const useSignal = <T>(
     };
   }, [location]);
 
-  return [value as T, set as (newValue: (Partial<T> | T) | Promise<T> | (() => Promise<T>)) => void];
+  return [value as T, set as (newValue: (null | undefined | Partial<T> | T) | Promise<T> | (() => Promise<T>)) => void];
 };

--- a/src/shared/utils/signals/signals.ts
+++ b/src/shared/utils/signals/signals.ts
@@ -116,8 +116,7 @@ const createSignal = <T>(
       });
     } catch (error) {
       //TODO:  Look at adding error handling here.
-      //throw new Error("In order to create a signal, you need to pass in an id");
-      console.error("Error in async signal:", error);
+      throw new Error(`Error in async signal, ${error}`);
     }
   }
 


### PR DESCRIPTION
Adding a custom hook to replace react's useSyncExternalStore.

Issues with it not triggering a re-render, due to reacts using Object.is as a comparator.

Wrote a custom hook to mimic the same functionality, with the option to add your own comparator or use an internal one by default that actually checks if the values are different from previousValues